### PR TITLE
docker-compose: support deploy.resources

### DIFF
--- a/templates/_deployment.tpl
+++ b/templates/_deployment.tpl
@@ -85,6 +85,7 @@ spec:
   {{- range $containerIndex, $container := $containers -}}
   {{-   $environments := include "stack.helpers.normalizeKV" $container.environment | fromYaml -}}
   {{-   $volumeMount := index $volumeMounts $containerIndex -}}
+  {{-   $resources := include "getPath" (list $container "deploy.resources") | fromYaml -}}
   {{-   $maybeWithContainerIndex := "" -}}
   {{-   if gt $containerIndex 0 -}}
   {{-     $maybeWithContainerIndex = printf "-%d" $containerIndex -}}
@@ -97,6 +98,13 @@ spec:
       {{- if $container.hostname }}
       hostname: {{ $container.hostname | quote }}
       {{- end -}}
+      
+      {{- if $resources }}
+      resources:
+        requests: {{ $resources.reservations | default $resources.requests | include "schema.normalizeCPU" | nindent 10 }}
+        limits: {{ $resources.limits | include "schema.normalizeCPU" | nindent 10 }}
+      {{- end -}}
+
       {{- if $container.command }}
       args: {{ $container.command | include "stack.helpers.normalizeCommand" | nindent 12 }}
       {{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -245,3 +245,22 @@ Result is a dict { "data": $mergedData }
 {{-   end -}}
 {{ dict "data" $newDst | toYaml }}
 {{- end -}}
+
+{{/** Get path (a.b.c.d) */}}
+{{- define "getPath" -}}
+{{-   $object := index . 0 -}}
+{{-   $paths := splitList "." (index . 1) -}}
+{{-   range $paths -}}
+{{-     $object = $object | pluck . | first -}}
+{{-   end -}}
+{{ $object | toYaml }}
+{{- end -}}
+
+{{/** Rename cpus -> cpu */}}
+{{- define "schema.normalizeCPU" -}}
+{{-   if and . (.cpus) -}}
+{{-     $_ := set . "cpu" .cpus -}}
+{{-     $_ := unset . "cpus" -}}
+{{-   end -}}
+{{- . | toYaml -}}
+{{- end -}}


### PR DESCRIPTION
I have added support for `services.XXX.deploy.resources`.
```yaml
resources:
  reservations:
    cpus: 1
    memory: 2Gi
  limits:
    cpus: 2
```
Would be convert to:
```yaml
...
containers:
- resources:
    limits:
      cpu: 2
    requests:
      cpu: 1
      memory: 2Gi