### PR TITLE
Bug fixs, features and improvement for v1.9.0

### DIFF
--- a/templates/_container.tpl
+++ b/templates/_container.tpl
@@ -88,7 +88,7 @@
 {{- /* Set container.volumeMounts */ -}}
 {{-     $_ := set $container "volumeMounts" $volumeMounts }}
 {{- /* Set container.name */ -}}
-{{-     $name := $container.container_name | default (printf "%s%s" $name $maybeWithContainerIndex) | replace "_" "-" }}
+{{-     $name := $container.container_name | default $container.name | default (printf "%s%s" $name $maybeWithContainerIndex) | replace "_" "-" }}
 {{-     $_ := set $container "name" $name }}
   - {{ include "stack.helpers.containerSpec" $container | nindent 4 | trim }}
 {{-   end -}}

--- a/templates/_container.tpl
+++ b/templates/_container.tpl
@@ -1,0 +1,106 @@
+
+{{- define "stack.helpers.containerSpec" -}}
+{{- $container := . -}}
+
+name: {{ $container.name | quote }}
+image: {{ $container.image | quote }}
+
+{{- if $container.entrypoint }}
+command: {{ $container.entrypoint | include "stack.helpers.normalizeEntrypoint" | nindent 12 }}
+{{- end -}}
+
+{{- if $container.command }}
+args: {{ $container.command | include "stack.helpers.normalizeCommand" | nindent 12 }}
+{{- end -}}
+
+{{- if $container.hostname }}
+hostname: {{ $container.hostname | quote }}
+{{- end -}}
+
+{{- $resources := include "getPath" (list $container "deploy.resources") | fromYaml -}}
+{{- if $resources }}
+resources:
+  requests: {{ $resources.reservations | default $resources.requests | include "schema.normalizeCPU" | nindent 10 }}
+  limits: {{ $resources.limits | include "schema.normalizeCPU" | nindent 10 }}
+{{- end -}}
+
+{{- if or $container.privileged $container.cap_add $container.cap_drop }}
+securityContext:
+  {{- if $container.privileged }}
+  privileged: {{ $container.privileged }}
+  {{- end -}}
+  {{- if or $container.cap_add $container.cap_drop }}
+  capabilities:
+    {{- if $container.cap_add }}
+    add: {{ $container.cap_add | toYaml | nindent 16 }}
+    {{- end -}}
+    {{- if $container.cap_drop }}
+    drop: {{ $container.cap_drop | toYaml | nindent 16 }}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if $container.environment }}
+env:
+  {{- range $envName, $envValue := $container.environment }}
+  - name: {{ $envName | quote }}
+    value: {{ $envValue | quote }}
+  {{- end -}}
+{{- end -}}
+
+{{- if $container.volumeMounts }}
+volumeMounts:
+  {{- range $volName, $volValue := $container.volumeMounts -}}
+  {{- if eq (get $volValue "volumeKind") "Volume" }}
+  - mountPath: {{ get $volValue "dst" | quote }}
+    name: {{ $volName | quote }}
+    {{- if get $volValue "subPath" }}
+    subPath: {{ get $volValue "subPath" | quote }}
+    {{- end -}}
+    {{- if get $volValue "readOnly" }}
+    readOnly: {{ get $volValue "readOnly" }}
+    {{- end }}
+  {{- end -}}
+  {{- if eq (get $volValue "volumeKind") "ConfigMap" }}
+  - mountPath: {{ get $volValue "target" | default (printf "/%s" (get $volValue "originalName")) | quote }}
+    name: {{ $volName | quote }}
+    {{- if get $volValue "file" }}
+    subPath: {{ get $volValue "file" | base | quote }}
+    {{- end -}}
+  {{- end -}}
+  {{- if eq (get $volValue "volumeKind") "Secret" }}
+  - mountPath: {{ get $volValue "target" | default (printf "/run/secrets/%s" (get $volValue "originalName")) | quote }}
+    name: {{ $volName | quote }}
+    {{- if get $volValue "file" }}
+    subPath: {{ get $volValue "file" | base | quote }}
+    {{- end -}}
+  {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if and $container.healthcheck ($container.healthcheck | pluck "test" | first) (not ($container.healthcheck | pluck "disabled" | first)) -}}
+{{ $healthCheckCommand := include "stack.helpers.normalizeHealthCheckCommand" $container.healthcheck.test | fromYaml -}}
+{{- if $healthCheckCommand }}
+livenessProbe:
+  exec:
+    command: {{ include "stack.helpers.normalizeHealthCheckCommand" $container.healthcheck.test | nindent 16 }}
+  {{- if $container.healthcheck.start_period }}
+  initialDelaySeconds: {{ include "stack.helpers.normalizeDuration" $container.healthcheck.start_period }}
+  {{- end -}}
+  {{- if $container.healthcheck.interval }}
+  periodSeconds: {{ include "stack.helpers.normalizeDuration" $container.healthcheck.interval }}
+  {{- end -}}
+  {{- if $container.healthcheck.timeout }}
+  timeoutSeconds: {{ include "stack.helpers.normalizeDuration" $container.healthcheck.timeout }}
+  {{- end -}}
+  {{- if $container.healthcheck.retries }}
+  failureThreshold: {{ $container.healthcheck.retries }}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- if $container.imagePullPolicy }}
+imagePullPolicy: {{ $container.imagePullPolicy }}
+{{- end -}}
+
+{{- end -}}

--- a/templates/_container.tpl
+++ b/templates/_container.tpl
@@ -49,7 +49,7 @@
 {{-         $name := $volName | replace "_" "-" -}}
 {{-         $volume := merge (dict "name" $name "dst" $mountPath "readOnly" $readOnly) (get $volumes $name) -}}
 {{-         $volumeMounts = append $volumeMounts $volume -}}
-{{-         if and (eq $owner_kind "StatefulSet") (ne (get $volume "type") "emptyDir") (get $volume "dynamic") -}}
+{{-         if and (eq $owner_kind "StatefulSet") (ne $volume.type "emptyDir") (not $volume.external) (get $volume "dynamic") -}}
 {{-         else -}}
 {{-           $_ := set $podVolumes $name $volume -}}
 {{-         end -}}

--- a/templates/_container.tpl
+++ b/templates/_container.tpl
@@ -166,8 +166,9 @@ volumeMounts:
   {{- if eq (get $volValue "volumeKind") "Secret" }}
   - mountPath: {{ get $volValue "target" | default (printf "/run/secrets/%s" (get $volValue "originalName")) | quote }}
     name: {{ $volName | quote }}
-    {{- if get $volValue "file" }}
-    subPath: {{ get $volValue "file" | base | quote }}
+    {{- $subPath := $volValue.file | default $volValue.subPath -}}
+    {{- if $subPath }}
+    subPath: {{ $subPath | base | quote }}
     {{- end -}}
   {{- end -}}
   {{- end -}}

--- a/templates/_container.tpl
+++ b/templates/_container.tpl
@@ -1,4 +1,99 @@
 
+{{- define "stack.helpers.containerList" -}}
+{{-   $Values := .Values -}}
+{{-   $volumes := .volumes -}}
+{{-   $configs := .configs -}}
+{{-   $secrets := .secrets -}}
+{{-   $name := .name -}}
+{{-   $containers := .containers -}}
+{{- /* TODO: deduplicate template process */ -}}
+{{-   $owner_kind := .owner_kind -}}
+{{- /* TODO: current implementation mutate parent data */ -}}
+{{-   $podVolumes := .podVolumes }}
+{{- /* Iterate over containers*/ -}}
+{{-   range $index, $container := $containers }}
+{{-     $maybeWithContainerIndex := "" -}}
+{{-     if gt $index 0 -}}
+{{-       $maybeWithContainerIndex = printf "-%d" $index -}}
+{{-     end -}}
+{{-     $volumeMounts := dict -}}
+{{- /* VOLUMES */ -}}
+{{-     range $volIndex, $volValue := $container.volumes -}}
+{{-       $list := splitList ":" $volValue -}}
+{{-       $volName := first $list -}}
+{{-       $mountPath := index $list 1 -}}
+{{- /* Readonly mount support */ -}}
+{{-       $readOnly := false -}}
+{{-       if and (len $list | lt 2) -}}
+{{-         if index $list 2 | eq "ro" -}}
+{{-           $readOnly = true -}}
+{{-         end -}}
+{{-       end -}}
+{{- /* Hostpath scenarios */ -}}
+{{-       if hasPrefix "/" $volName -}}
+{{-         $volume := dict "volumeKind" "Volume" "type" "hostPath" "src" $volName "dst" $mountPath "readOnly" $readOnly -}}
+{{-         $_ := set $podVolumes (printf "volume%s-%d" $maybeWithContainerIndex $volIndex) $volume -}}
+{{-         $_ := set $volumeMounts (printf "volume%s-%d" $maybeWithContainerIndex $volIndex) $volume -}}
+{{-       else if hasPrefix "./" $volName -}}
+{{-         $src := clean (printf "%s/%s" (default "." $Values.chdir) $volName) -}}
+{{-         if not (isAbs $src) -}}
+{{-           fail "volume path or chidir has to be absolute." -}}
+{{-         end -}}
+{{-         $volume = (dict "volumeKind" "Volume" "type" "hostPath" "src" $src "dst" $mountPath "readOnly" $readOnly) -}}
+{{-         $_ := set $podVolumes (printf "volume%s-%d" $maybeWithContainerIndex $volIndex) $volume -}}
+{{-         $_ := set $volumeMounts (printf "volume%s-%d" $maybeWithContainerIndex $volIndex) $volume -}}
+{{- /* Else */ -}}
+{{-       else -}}
+{{-         $volName = $volName | replace "_" "-" -}}
+{{-         $curr := get $volumes $volName | deepCopy -}}
+{{-         $curr = mergeOverwrite $curr (dict "dst" $mountPath "readOnly" $readOnly) -}}
+{{-         $_ := set $volumeMounts $volName $curr -}}
+{{-         if and (eq $owner_kind "StatefulSet") (ne (get $curr "type") "emptyDir") (get $curr "dynamic") -}}
+{{-         else -}}
+{{-           $_ := set $podVolumes $volName $curr -}}
+{{-         end -}}
+{{-       end -}}
+{{-     end -}}
+{{- /* CONFIG */ -}}
+{{-     range $volValue := $container.configs -}}
+{{-       if (typeOf $volValue) | ne "string" -}}
+{{-         $volName := get $volValue "source" | replace "_" "-" -}}
+{{-         $curr := get $configs $volName | deepCopy -}}
+{{-         $curr = mergeOverwrite $curr $volValue -}}
+{{-         $_ := set $podVolumes $volName $curr -}}
+{{-         $_ := set $volumeMounts $volName $curr -}}
+{{-       else -}}
+{{-         $volName := $volValue | replace "_" "-" -}}
+{{-         $_ := set $podVolumes $volName (get $configs $volName) -}}
+{{-         $_ := set $volumeMounts $volName (get $configs $volName) -}}
+{{-       end -}}
+{{-     end -}}
+{{- /* SECRET: copy of CONFIG */ -}}
+{{-     range $volValue := $container.secrets -}}
+{{-       if (typeOf $volValue) | ne "string" -}}
+{{-         $volName := get $volValue "source" | replace "_" "-" -}}
+{{-         $curr := get $secrets $volName | deepCopy -}}
+{{-         $curr = mergeOverwrite $curr $volValue -}}
+{{-         $_ := set $podVolumes $volName $curr -}}
+{{-         $_ := set $volumeMounts $volName $curr -}}
+{{-       else -}}
+{{-         $volName := $volValue | replace "_" "-" -}}
+{{-         $_ := set $podVolumes $volName (get $secrets $volName) -}}
+{{-         $_ := set $volumeMounts $volName (get $secrets $volName) -}}
+{{-       end -}}
+{{-     end -}}
+{{- /* Set container.environments */ -}}
+{{-     $environment := include "stack.helpers.normalizeKV" $container.environment | fromYaml }}
+{{-     $_ := set $container "environment" $environment }}
+{{- /* Set container.volumeMounts */ -}}
+{{-     $_ := set $container "volumeMounts" $volumeMounts }}
+{{- /* Set container.name */ -}}
+{{-     $name := $container.container_name | default (printf "%s%s" $name $maybeWithContainerIndex) | replace "_" "-" }}
+{{-     $_ := set $container "name" $name }}
+  - {{ include "stack.helpers.containerSpec" $container | nindent 4 | trim }}
+{{-   end -}}
+{{- end -}}
+
 {{- define "stack.helpers.containerSpec" -}}
 {{- $container := . -}}
 

--- a/templates/_deployment.tpl
+++ b/templates/_deployment.tpl
@@ -105,8 +105,8 @@ spec:
   volumes:
   {{- range $volValue := $podVolumes }}
   {{-   $volName := $volValue.name }}
-    {{- if eq $volValue.volumeKind "Volume" }}
     - name: {{ $volName | quote }}
+    {{- if eq $volValue.volumeKind "Volume" }}
       {{- if eq $volValue.type "hostPath" }}
       hostPath:
         path: {{ $volValue.src | default $volValue.source | quote }}
@@ -117,20 +117,23 @@ spec:
         claimName: {{ $volValue.externalName | quote }}
       {{- end }}
     {{- end }}
-    - name: {{ $volName | quote }}
+    {{- if eq $volValue.volumeKind "ConfigMap" }}
       configMap:
-        name: {{ get $volValue "externalName" | quote }}
-        {{- if get $volValue "mode" }}
-        defaultMode: {{ get $volValue "mode" }}
-        {{- end -}}
-    {{- end -}}
-    {{- if eq (get $volValue "volumeKind") "Secret" }}
-    - name: {{ $volName | quote }}
+        name: {{ $volValue.externalName | quote }}
+        {{- if $volValue.mode }}
+        defaultMode: {{ $volValue.mode }}
+        {{- end }}
+    {{- end }}
+    {{- if eq $volValue.volumeKind "Secret" }}
       secret:
-        secretName: {{ get $volValue "externalName" | quote }}
-    {{- end -}}
-    {{- end -}}
-  {{- end -}}
+        secretName: {{ $volValue.externalName | quote }}
+        {{- if $volValue.mode }}
+        defaultMode: {{ $volValue.mode }}
+        {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
+
   {{- if $service.imagePullSecrets }}
   imagePullSecrets:
     - name: {{ $service.imagePullSecrets }}

--- a/templates/_deployment.tpl
+++ b/templates/_deployment.tpl
@@ -103,7 +103,8 @@ spec:
 
   {{- if $podVolumes }}
   volumes:
-    {{- range $volName, $volValue := $podVolumes -}}
+    {{- range $volValue := $podVolumes -}}
+    {{- $volName := $volValue.name -}}
     {{- if eq (get $volValue "volumeKind") "Volume" }}
     - name: {{ $volName | quote }}
       {{- if get $volValue "type" | eq "hostPath" }}

--- a/templates/_deployment.tpl
+++ b/templates/_deployment.tpl
@@ -85,6 +85,7 @@ spec:
   {{- range $containerIndex, $container := $containers -}}
   {{-   $environments := include "stack.helpers.normalizeKV" $container.environment | fromYaml -}}
   {{-   $volumeMount := index $volumeMounts $containerIndex -}}
+  {{-   $resources := include "getPath" (list $container "deploy.resources") | fromYaml -}}
   {{-   $maybeWithContainerIndex := "" -}}
   {{-   if gt $containerIndex 0 -}}
   {{-     $maybeWithContainerIndex = printf "-%d" $containerIndex -}}
@@ -97,6 +98,13 @@ spec:
       {{- if $container.hostname }}
       hostname: {{ $container.hostname | quote }}
       {{- end -}}
+      
+      {{- if $resources }}
+      resources:
+        requests: {{ $resources.reservations | default $resources.requests | include "schema.normalizeCPU" | nindent 10 }}
+        limits: {{ $resources.limits | include "schema.normalizeCPU" | nindent 10 }}
+      {{- end -}}
+
       {{- if $container.command }}
       args: {{ $container.command | include "stack.helpers.normalizeCommand" | nindent 12 }}
       {{- end -}}

--- a/templates/_deployment.tpl
+++ b/templates/_deployment.tpl
@@ -97,7 +97,7 @@ spec:
   {{ include "stack.helpers.containerList" (merge dict $context $params) }}
   {{- end }}
 
-  {{- if eq "host" ($containers | first | pluck "network_mode" | first) }}
+  {{- if eq "host" ($containers | first | pluck "network_mode" | first | default "default") }}
   hostNetwork: true
   {{- end }}
 

--- a/templates/_deployment.tpl
+++ b/templates/_deployment.tpl
@@ -160,15 +160,15 @@ spec:
 {{-   $containers := omit $service "containers" | prepend ($service.containers | default list) -}}
 {{-   $initContainers := $service.initContainers | default list -}}
 
-{{-   range $containerIndex, $container := (concat $containers $initContainers) -}}
-{{-     range $volIndex, $volValue := $container.volumes -}}
-{{-       $list := splitList ":" $volValue -}}
+{{-   range $container := (concat $containers $initContainers) -}}
+{{-     range $mount := $container.volumes -}}
+{{-       $list := splitList ":" $mount -}}
 {{-       $volName := first $list -}}
 {{-       if not (or (hasPrefix "/" $volName) (hasPrefix "./" $volName)) -}}
 {{-         $volName = $volName | replace "_" "-" -}}
 {{- /* TODO: Check `volumes.XXX` existences and validity */ -}}
 {{-         $curr := get $volumes $volName | deepCopy -}}
-{{-         if and (eq $kind "StatefulSet") (ne (get $curr "type") "emptyDir") (get $curr "dynamic") -}}
+{{-         if and (eq $kind "StatefulSet") (ne $curr.type "emptyDir") (not $curr.external) (get $curr "dynamic") -}}
 {{-           $_ := set $volumeClaimTemplates $volName $curr -}}
 {{-         end -}}
 {{-       end -}}

--- a/templates/_deployment.tpl
+++ b/templates/_deployment.tpl
@@ -142,9 +142,9 @@ spec:
 
 {{- define "stack.deployment" -}}
 {{-   $name := .name | replace "_" "-" -}}
+{{-   $kind := .kind -}}
 {{-   $service := .service -}}
 {{-   $replicas := $service | pluck "deploy"| first | default dict | pluck "replicas" | first -}}
-{{-   $kind := include "stack.helpers.deploymentKind" $service -}}
 {{-   $volumes := include "stack.helpers.volumes" (dict "Values" .Values) | fromYaml -}}
 {{-   $configs := include "stack.helpers.configs" (dict "Values" .Values) | fromYaml -}}
 {{-   $secrets := include "stack.helpers.secrets" (dict "Values" .Values) | fromYaml -}}
@@ -170,6 +170,7 @@ spec:
 {{-     end -}}
 {{-   end -}}
 {{- $podSpec := include "stack.helpers.podSpec" (dict "name" $name "owner_kind" $kind "service" $service "volumes" $volumes "configs" $configs "secrets" $secrets "containers" $containers "initContainers" $initContainers "affinities" $affinities "restartPolicy" $restartPolicy) | fromYaml -}}
+
 {{- if eq $kind "Job" -}}
 apiVersion: batch/v1
 kind: {{ $kind }}
@@ -178,6 +179,7 @@ metadata:
 spec:
   template:
     {{ mergeOverwrite (dict "spec" (dict "restartPolicy" "Never")) $podSpec | toYaml | nindent 4 }}
+
 {{- else if eq $kind "CronJob" -}}
 apiVersion: batch/v1beta1
 kind: {{ $kind }}
@@ -189,6 +191,7 @@ spec:
     spec:
       template:
         {{ mergeOverwrite (dict "spec" (dict "restartPolicy" "Never")) $podSpec | toYaml | nindent 8 }}
+
 {{- else -}}
 apiVersion: apps/v1
 kind: {{ $kind }}

--- a/templates/_deployment.tpl
+++ b/templates/_deployment.tpl
@@ -97,6 +97,10 @@ spec:
   {{ include "stack.helpers.containerList" (merge dict $context $params) }}
   {{- end }}
 
+  {{- if eq "host" ($containers | first | pluck "network_mode" | first) }}
+  hostNetwork: true
+  {{- end }}
+
   {{- if $podVolumes }}
   volumes:
     {{- range $volName, $volValue := $podVolumes -}}

--- a/templates/_deployment.tpl
+++ b/templates/_deployment.tpl
@@ -82,107 +82,23 @@ spec:
     nameservers: {{ $service.dns | toYaml | nindent 10 }}
   {{- end }}
   containers:
-  {{- range $containerIndex, $container := $containers -}}
-  {{-   $environments := include "stack.helpers.normalizeKV" $container.environment | fromYaml -}}
-  {{-   $volumeMount := index $volumeMounts $containerIndex -}}
-  {{-   $resources := include "getPath" (list $container "deploy.resources") | fromYaml -}}
-  {{-   $maybeWithContainerIndex := "" -}}
-  {{-   if gt $containerIndex 0 -}}
-  {{-     $maybeWithContainerIndex = printf "-%d" $containerIndex -}}
+  {{- range $containerIndex, $container := $containers }}
+  {{- /** Set container.environments */}}
+  {{-   $environment := include "stack.helpers.normalizeKV" $container.environment | fromYaml }}
+  {{-   $_ := set $container "environment" $environment }}
+  {{- /** Set container.volumeMounts */}}
+  {{-   $volumeMount := index $volumeMounts $containerIndex }}
+  {{-   $_ := set $container "volumeMounts" $volumeMount }}
+  {{- /** Set container.name */}}
+  {{-   $maybeWithContainerIndex := "" }}
+  {{-   if gt $containerIndex 0 }}
+  {{-     $maybeWithContainerIndex = printf "-%d" $containerIndex }}
   {{-   end }}
-    - name: {{ $container.container_name | default (printf "%s%s" $name $maybeWithContainerIndex) | replace "_" "-" | quote }}
-      image: {{ $container.image | quote }}
-      {{- if $container.entrypoint }}
-      command: {{ $container.entrypoint | include "stack.helpers.normalizeEntrypoint" | nindent 12 }}
-      {{- end -}}
-      {{- if $container.hostname }}
-      hostname: {{ $container.hostname | quote }}
-      {{- end -}}
-      
-      {{- if $resources }}
-      resources:
-        requests: {{ $resources.reservations | default $resources.requests | include "schema.normalizeCPU" | nindent 10 }}
-        limits: {{ $resources.limits | include "schema.normalizeCPU" | nindent 10 }}
-      {{- end -}}
-
-      {{- if $container.command }}
-      args: {{ $container.command | include "stack.helpers.normalizeCommand" | nindent 12 }}
-      {{- end -}}
-      {{- if or $container.privileged $container.cap_add $container.cap_drop }}
-      securityContext:
-        {{- if $container.privileged }}
-        privileged: {{ $container.privileged }}
-        {{- end -}}
-        {{- if or $container.cap_add $container.cap_drop }}
-        capabilities:
-          {{- if $container.cap_add }}
-          add: {{ $container.cap_add | toYaml | nindent 16 }}
-          {{- end -}}
-          {{- if $container.cap_drop }}
-          drop: {{ $container.cap_drop | toYaml | nindent 16 }}
-          {{- end -}}
-        {{- end -}}
-      {{- end -}}
-      {{- if $environments }}
-      env:
-        {{- range $envName, $envValue := $environments }}
-        - name: {{ $envName | quote }}
-          value: {{ $envValue | quote }}
-        {{- end -}}
-      {{- end -}}
-      {{- if $volumeMount }}
-      volumeMounts:
-        {{- range $volName, $volValue := $volumeMount -}}
-        {{- if eq (get $volValue "volumeKind") "Volume" }}
-        - mountPath: {{ get $volValue "dst" | quote }}
-          name: {{ $volName | quote }}
-          {{- if get $volValue "subPath" }}
-          subPath: {{ get $volValue "subPath" | quote }}
-          {{- end -}}
-          {{- if get $volValue "readOnly" }}
-          readOnly: {{ get $volValue "readOnly" }}
-          {{- end }}
-        {{- end -}}
-        {{- if eq (get $volValue "volumeKind") "ConfigMap" }}
-        - mountPath: {{ get $volValue "target" | default (printf "/%s" (get $volValue "originalName")) | quote }}
-          name: {{ $volName | quote }}
-          {{- if get $volValue "file" }}
-          subPath: {{ get $volValue "file" | base | quote }}
-          {{- end -}}
-        {{- end -}}
-        {{- if eq (get $volValue "volumeKind") "Secret" }}
-        - mountPath: {{ get $volValue "target" | default (printf "/run/secrets/%s" (get $volValue "originalName")) | quote }}
-          name: {{ $volName | quote }}
-          {{- if get $volValue "file" }}
-          subPath: {{ get $volValue "file" | base | quote }}
-          {{- end -}}
-        {{- end -}}
-        {{- end -}}
-      {{- end -}}
-      {{- if and $container.healthcheck ($container.healthcheck | pluck "test" | first) (not ($container.healthcheck | pluck "disabled" | first)) -}}
-      {{ $healthCheckCommand := include "stack.helpers.normalizeHealthCheckCommand" $container.healthcheck.test | fromYaml -}}
-      {{- if $healthCheckCommand }}
-      livenessProbe:
-        exec:
-          command: {{ include "stack.helpers.normalizeHealthCheckCommand" $container.healthcheck.test | nindent 16 }}
-        {{- if $container.healthcheck.start_period }}
-        initialDelaySeconds: {{ include "stack.helpers.normalizeDuration" $container.healthcheck.start_period }}
-        {{- end -}}
-        {{- if $container.healthcheck.interval }}
-        periodSeconds: {{ include "stack.helpers.normalizeDuration" $container.healthcheck.interval }}
-        {{- end -}}
-        {{- if $container.healthcheck.timeout }}
-        timeoutSeconds: {{ include "stack.helpers.normalizeDuration" $container.healthcheck.timeout }}
-        {{- end -}}
-        {{- if $container.healthcheck.retries }}
-        failureThreshold: {{ $container.healthcheck.retries }}
-        {{- end -}}
-      {{- end -}}
-      {{- end -}}
-      {{- if $container.imagePullPolicy }}
-      imagePullPolicy: {{ $container.imagePullPolicy }}
-      {{- end -}}
+  {{-   $name := $container.container_name | default (printf "%s%s" $name $maybeWithContainerIndex) | replace "_" "-" }}
+  {{-   $_ := set $container "name" $name }}
+  - {{ include "stack.helpers.containerSpec" $container | nindent 4 | trim }}
   {{- end -}}
+
   {{- if $serviceVolumes }}
   volumes:
     {{- range $volName, $volValue := $serviceVolumes -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -245,3 +245,22 @@ Result is a dict { "data": $mergedData }
 {{-   end -}}
 {{ dict "data" $newDst | toYaml }}
 {{- end -}}
+
+{{/** Get path (a.b.c.d) */}}
+{{- define "getPath" -}}
+{{-   $object := index . 0 -}}
+{{-   $paths := splitList "." (index . 1) -}}
+{{-   range $paths -}}
+{{-     $object = $object | pluck . | first -}}
+{{-   end -}}
+{{ $object | toYaml }}
+{{- end -}}
+
+{{/** Rename cpus -> cpu */}}
+{{- define "schema.normalizeCPU" -}}
+{{-   if and . (.cpus) -}}
+{{-     $_ := set . "cpu" .cpus -}}
+{{-     $_ := unset . "cpus" -}}
+{{-   end -}}
+{{- . | toYaml -}}
+{{- end -}}

--- a/templates/_pv.tpl
+++ b/templates/_pv.tpl
@@ -40,11 +40,11 @@ All the volumes
 {{-   range $name, $service := .Values.services -}}
 {{-     $deploymentKind := include "stack.helpers.deploymentKind" $service -}}
 {{-     $containers := omit $service "containers" | prepend ($service.containers | default list) -}}
-{{-     range $containerIndex, $container := $containers -}}
+{{-     range $container := $containers -}}
 {{-       range $volValue := $container.volumes -}}
-{{-         $list := splitList ":" $volValue -}}
-{{-         $volName := first $list | replace "_" "-" -}}
-{{-         if and (not (hasPrefix "/" $volName)) (not (hasPrefix "./" $volName)) -}}
+{{-         $mountOptions := include "stack.helpers.volumeMountOptions" $volValue | fromYaml -}}
+{{-         $volName := $mountOptions.source | replace "_" "-" -}}
+{{-         if not (or (hasPrefix "/" $volName) (hasPrefix "./" $volName)) -}}
 {{-           $volume := get $volumes $volName -}}
 {{-           $_ := set $volume "deploymentKind" $deploymentKind -}}
 {{-         end -}}

--- a/templates/stack.yml
+++ b/templates/stack.yml
@@ -8,14 +8,14 @@
 {{-       $pv := include "stack.pv" (dict "volName" $volName "volValue" $volValue "Values" $Values "Release" $Release) | fromYaml -}}
 {{-       $override := $Values | pluck "volumes" | first | default dict | pluck (get $volValue "originalName") | first | default dict | pluck "PV" | first | default dict }}
 ---
-{{ include "stack.helpers.mergeDeepOverwrite" (list $pv $override) | fromYaml | pluck "data" | first | toYaml -}}
+{{        include "stack.helpers.mergeDeepOverwrite" (list $pv $override) | fromYaml | pluck "data" | first | toYaml -}}
 {{-     end -}}
 {{/* volumes: pvc */}}
 {{-     if or (ne (get $volValue "deploymentKind") "StatefulSet") (not (get $volValue "dynamic")) -}}
 {{-       $pvc := include "stack.pvc" (dict "volName" $volName "volValue" $volValue) | fromYaml -}}
 {{-       $override := $Values | pluck "volumes" | first | default dict | pluck (get $volValue "originalName") | first | default dict | pluck "PVC" | first | default dict }}
 ---
-{{ include "stack.helpers.mergeDeepOverwrite" (list $pvc $override) | fromYaml | pluck "data" | first | toYaml -}}
+{{        include "stack.helpers.mergeDeepOverwrite" (list $pvc $override) | fromYaml | pluck "data" | first | toYaml -}}
 {{-     end -}}
 {{-   end -}}
 {{- end -}}
@@ -25,9 +25,8 @@
 {{-   if not (get $volValue "external") -}}
 {{-     $config := include "stack.configMap" (dict "volName" $volName "volValue" $volValue "Values" $Values "Release" $Release) | fromYaml -}}
 {{-     $override := $Values | pluck "configs" | first | default dict | pluck (get $volValue "originalName") | first | default dict | pluck "ConfigMap" | first | default dict }}
-{{-     if $config }}
----
-{{ include "stack.helpers.mergeDeepOverwrite" (list $config $override) | fromYaml | pluck "data" | first | toYaml -}}
+{{-     if $config }}---
+{{        include "stack.helpers.mergeDeepOverwrite" (list $config $override) | fromYaml | pluck "data" | first | toYaml -}}
 {{-     end -}}
 {{-   end -}}
 {{- end -}}
@@ -37,9 +36,8 @@
 {{-   if not (get $volValue "external") -}}
 {{-     $secret := include "stack.secret" (dict "volName" $volName "volValue" $volValue "Values" $Values "Release" $Release) | fromYaml -}}
 {{-     $override := $Values | pluck "secrets" | first | default dict | pluck (get $volValue "originalName") | first | default dict | pluck "Secret" | first | default dict }}
-{{-     if $secret }}
----
-{{ include "stack.helpers.mergeDeepOverwrite" (list $secret $override) | fromYaml | pluck "data" | first | toYaml -}}
+{{-     if $secret }}---
+{{        include "stack.helpers.mergeDeepOverwrite" (list $secret $override) | fromYaml | pluck "data" | first | toYaml -}}
 {{-     end -}}
 {{-   end -}}
 {{- end -}}
@@ -48,27 +46,24 @@
 {{- range $name, $service:= .Values.services }}
 {{/* services: clusterIP */}}
 {{-   $clusterIP := include "stack.service.clusterIP" (dict "name" $name "service" $service "Values" $Values "Release" $Release) | fromYaml -}}
-{{-   $override := $Values | pluck "services" | first | default dict | pluck $name | first | default dict | pluck "ClusterIP" | first | default dict -}}
-{{-   if $clusterIP }}
----
-{{ include "stack.helpers.mergeDeepOverwrite" (list $clusterIP $override) | fromYaml | pluck "data" | first | toYaml -}}
+{{-   $override := $service | pluck "ClusterIP" | first | default dict -}}
+{{-   if $clusterIP }}---
+{{      include "stack.helpers.mergeDeepOverwrite" (list $clusterIP $override) | fromYaml | pluck "data" | first | toYaml -}}
 {{-   end }}
 {{/* services: nodePort */}}
 {{-   $nodePort := include "stack.service.nodePort" (dict "name" $name "service" $service "Values" $Values "Release" $Release) | fromYaml -}}
-{{-   $override := $Values | pluck "services" | first | default dict | pluck $name | first | default dict | pluck "NodePort" | first | default dict -}}
-{{-   if $nodePort }}
----
-{{ include "stack.helpers.mergeDeepOverwrite" (list $nodePort $override) | fromYaml | pluck "data" | first | toYaml -}}
+{{-   $override := $service | pluck "NodePort" | first | default dict -}}
+{{-   if $nodePort }}---
+{{       include "stack.helpers.mergeDeepOverwrite" (list $nodePort $override) | fromYaml | pluck "data" | first | toYaml -}}
 {{-   end }}
 {{/* services: loadBalancer */}}
 {{-   $ports := include "stack.helpers.normalizePorts" $service.ports | fromYaml -}}
 {{-   range $protocol, $ports := pick $ports "tcp" "udp" -}}
 {{-     if $ports }}
 {{-       $loadBalancer := include "stack.service.loadBalancer" (dict "name" $name "protocol" $protocol "ports" $ports) | fromYaml -}}
-{{-       $override := $Values | pluck "services" | first | default dict | pluck $name | first | default dict | pluck "LoadBalancer" | first | default dict | pluck $protocol | first | default dict -}}
-{{-       if $loadBalancer }}
----
-{{ include "stack.helpers.mergeDeepOverwrite" (list $loadBalancer $override) | fromYaml | pluck "data" | first | toYaml -}}
+{{-       $override := $service | pluck "LoadBalancer" | first | default dict | pluck $protocol | first | default dict -}}
+{{-       if $loadBalancer }}---
+{{          include "stack.helpers.mergeDeepOverwrite" (list $loadBalancer $override) | fromYaml | pluck "data" | first | toYaml -}}
 {{-       end -}}
 {{-     end -}}
 {{-   end -}}
@@ -76,23 +71,24 @@
 {{-   range $segment, $ingressValue := include "stack.helpers.ingresses" (dict "name" $name "service" $service "Values" $Values "Release" $Release) | fromYaml -}}
 {{-     if and (get $ingressValue "hosts") (get $ingressValue "port") -}}
 {{-       $ingress := include "stack.ingress" (dict "name" $name "segment" $segment "ingress" $ingressValue) | fromYaml -}}
-{{-       $override := $Values | pluck "services" | first | default dict | pluck $name | first | default dict | pluck "Ingress" | first | default dict | pluck $segment | first | default dict }}
+{{-       $override := $service | pluck "Ingress" | first | default dict | pluck $segment | first | default dict }}
 ---
-{{ include "stack.helpers.mergeDeepOverwrite" (list $ingress $override) | fromYaml | pluck "data" | first | toYaml -}}
+{{        include "stack.helpers.mergeDeepOverwrite" (list $ingress $override) | fromYaml | pluck "data" | first | toYaml -}}
 {{-     end -}}
 {{-     if get $ingressValue "auth" -}}
 {{-       $auth := include "stack.ingress.auth"  (dict "name" $name "segment" $segment "ingress" $ingressValue) | fromYaml -}}
-{{-       $override := $Values | pluck "services" | first | default dict | pluck $name | first | default dict | pluck "Auth" | first | default dict | pluck $segment | first | default dict }}
+{{-       $override := $service | pluck "Auth" | first | default dict | pluck $segment | first | default dict }}
 ---
-{{ include "stack.helpers.mergeDeepOverwrite" (list $auth $override) | fromYaml | pluck "data" | first | toYaml -}}
+{{        include "stack.helpers.mergeDeepOverwrite" (list $auth $override) | fromYaml | pluck "data" | first | toYaml -}}
 {{-     end -}}
 {{-   end }}
 {{/* services: deployment */}}
-{{-   $deployment := include "stack.deployment" (dict "name" $name "service" $service "Values" $Values "Release" $Release) | fromYaml -}}
-{{-   $kind := get $deployment "kind" -}}
-{{-   $override := $Values | pluck "services" | first | default dict | pluck $name | first | default dict | pluck $kind | first | default dict -}}---
+{{-   $kind := include "stack.helpers.deploymentKind" $service -}}
+{{-   $deployment := include "stack.deployment" (dict "name" $name "kind" $kind "service" $service "Values" $Values "Release" $Release) | fromYaml -}}
+{{-   $override := $service | pluck $kind | first | default dict -}}
 {{/* $override | toYaml | fail */}}
-{{ include "stack.helpers.mergeDeepOverwrite" (list $deployment $override) | fromYaml | pluck "data" | first | toYaml -}}
+---
+{{    include "stack.helpers.mergeDeepOverwrite" (list $deployment $override) | fromYaml | pluck "data" | first | toYaml -}}
 {{- end -}}
 {{/* services: end */}}
 {{/* Raw */}}


### PR DESCRIPTION
What included:
- Support docker-compose style resources requests/limits via `services.XXX.deploy.resources`.
- Add support for extra key `initContainers`.
- Support Kubernetes Pod `hostNetwork: true` via docker-compose' `network_mode: host`.
- Add support for docker-compose's long-syntax `volumes` mount.
- Add support for volumes/secrets/config `subPath` mount.
- Fix: StatefulSet should now honor volumes with `external: true` (not create a `volumeClaimTemplate`).

 